### PR TITLE
修复 kotlin 模板不生成 Dagger**Component 的问题

### DIFF
--- a/MVPArmsTemplate/recipe.xml.ftl
+++ b/MVPArmsTemplate/recipe.xml.ftl
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<#import "root://activities/common/kotlin_macros.ftl" as kt>
+<#import "root://gradle-projects/NewArmsModule/kotlin_macros.ftl" as kt>
 <recipe>
 <@kt.addAllKotlinDependencies />
 <#if needActivity>

--- a/MVPArtTemplate/recipe.xml.ftl
+++ b/MVPArtTemplate/recipe.xml.ftl
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<#import "root://activities/common/kotlin_macros.ftl" as kt>
+<#import "root://gradle-projects/NewArmsModule/kotlin_macros.ftl" as kt>
 <recipe>
  <@kt.addAllKotlinDependencies />
 <#if needActivity>


### PR DESCRIPTION
使用 kotlin 时，会在 build.gradle 增加两行 dagger2 所需代码