### PR TITLE
修复使用 kotlin 模板时不会自动创建 Dagger**Component 的问题

### DIFF
--- a/MVPArmsTemplate/dagger2.gradle.ftl
+++ b/MVPArmsTemplate/dagger2.gradle.ftl
@@ -1,0 +1,3 @@
+dependencies {
+    kapt rootProject.ext.dependencies["dagger2-compiler"]
+}

--- a/MVPArmsTemplate/dagger2_macros.ftl
+++ b/MVPArmsTemplate/dagger2_macros.ftl
@@ -1,0 +1,7 @@
+<#macro addAllKaptDependencies>
+  <#if !isNewProject && ((language!'Java')?string == 'Kotlin')>
+    <apply plugin="kotlin-kapt" />
+    <merge from="root://activities/MVPArmsTemplate/dagger2.gradle.ftl"
+        to="${escapeXmlAttribute(projectOut)}/build.gradle" />
+  </#if>
+</#macro>

--- a/MVPArmsTemplate/recipe.xml.ftl
+++ b/MVPArmsTemplate/recipe.xml.ftl
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <#import "root://activities/common/kotlin_macros.ftl" as kt>
+<#import "root://activities/MVPArmsTemplate/dagger2_macros.ftl" as dagger2>
 <recipe>
 <@kt.addAllKotlinDependencies />
+<@dagger2.addAllKaptDependencies />
 <#if needActivity>
     <merge from="root/AndroidManifest.xml.ftl"
            to="${escapeXmlAttribute(manifestOut)}/AndroidManifest.xml" />

--- a/MVPArtTemplate/dagger2.gradle.ftl
+++ b/MVPArtTemplate/dagger2.gradle.ftl
@@ -1,0 +1,3 @@
+dependencies {
+    kapt rootProject.ext.dependencies["dagger2-compiler"]
+}

--- a/MVPArtTemplate/dagger2_macros.ftl
+++ b/MVPArtTemplate/dagger2_macros.ftl
@@ -1,0 +1,7 @@
+<#macro addAllKaptDependencies>
+  <#if !isNewProject && ((language!'Java')?string == 'Kotlin')>
+    <apply plugin="kotlin-kapt" />
+    <merge from="root://activities/MVPArmsTemplate/dagger2.gradle.ftl"
+        to="${escapeXmlAttribute(projectOut)}/build.gradle" />
+  </#if>
+</#macro>

--- a/MVPArtTemplate/recipe.xml.ftl
+++ b/MVPArtTemplate/recipe.xml.ftl
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <#import "root://activities/common/kotlin_macros.ftl" as kt>
+<#import "root://activities/MVPArmsTemplate/dagger2_macros.ftl" as dagger2>
 <recipe>
- <@kt.addAllKotlinDependencies />
+<@kt.addAllKotlinDependencies />
+<@dagger2.addAllKaptDependencies />
 <#if needActivity>
     <merge from="root/AndroidManifest.xml.ftl"
            to="${escapeXmlAttribute(manifestOut)}/AndroidManifest.xml" />


### PR DESCRIPTION
生成在 kotlin 使用 dagger2 时所需的 kapt 代码